### PR TITLE
Adding a console example

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,4 @@ Index:
 - [login-page.html](https://slensky.com/zendriver-examples/login-page.html)
 - [mouse-tester.html](https://slensky.com/zendriver-examples/mouse-tester.html)
 - [scrollable-cards.html](https://slensky.com/zendriver-examples/scrollable-cards.html)
+- [console.html](https://slensky.com/zendriver-examples/console.html)

--- a/console.html
+++ b/console.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Console Demo - Zendriver</title>
+  </head>
+  <body>
+    <div class="container">
+      <h1>Console Demo</h1>
+      <button id="myButton" onclick="console.log('Button clicked!')">Click me</button>
+    </div>
+</html>


### PR DESCRIPTION
Hey!
I'm writing a tutorial to show how to play with raw cdp commands (when people want to do something zendriver/kdriver does not offer directly as a feature, so they use tab.send() and tab.add_handler()).

For this tutorial I chose to use the console api to show how to enable it and then add handler to listen to it. So I added this simple html file for the example.

Any chance to get it merged and published?